### PR TITLE
Improve config flow handler compatibility

### DIFF
--- a/custom_components/kumo_cloud/config_flow.py
+++ b/custom_components/kumo_cloud/config_flow.py
@@ -2,14 +2,18 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.data_entry_flow import FlowResult
 
 from .const import DOMAIN
+
+if TYPE_CHECKING:
+    from homeassistant.data_entry_flow import FlowResult
+else:  # pragma: no cover - typing fallback for older Home Assistant versions
+    FlowResult = Any
 
 DATA_SCHEMA = vol.Schema(
     {
@@ -19,10 +23,11 @@ DATA_SCHEMA = vol.Schema(
 )
 
 
-class KumoCloudConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+class ConfigFlow(config_entries.ConfigFlow):
     """Handle a config flow for Kumo Cloud."""
 
     VERSION = 1
+    domain = DOMAIN
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Handle the initial step where the user enters credentials."""
@@ -45,3 +50,10 @@ class KumoCloudConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=DATA_SCHEMA,
             errors=errors,
         )
+
+if hasattr(config_entries, "HANDLERS"):
+    try:
+        config_entries.HANDLERS.register(DOMAIN)(ConfigFlow)
+    except ValueError:
+        # Handler already registered on this core version.
+        pass


### PR DESCRIPTION
## Summary
- define the Kumo Cloud config flow without relying on the removed HANDLERS decorator so it imports on newer Home Assistant versions
- register the flow handler conditionally when the legacy registry is present to remain compatible with older cores

## Testing
- python -m compileall custom_components/kumo_cloud

------
https://chatgpt.com/codex/tasks/task_e_68d322b32728833388a89993ccaf8e8e