### PR TITLE
Fix config flow lazy import initialization

### DIFF
--- a/custom_components/kumo_cloud/config_flow.py
+++ b/custom_components/kumo_cloud/config_flow.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
-
-import voluptuous as vol
+import importlib
+from types import ModuleType
+from typing import TYPE_CHECKING, Any, cast
 
 from homeassistant import config_entries
 
@@ -12,15 +12,13 @@ from .const import DOMAIN
 
 if TYPE_CHECKING:
     from homeassistant.data_entry_flow import FlowResult
+    from voluptuous import Schema as VolSchema
 else:  # pragma: no cover - typing fallback for older Home Assistant versions
     FlowResult = Any
+    VolSchema = Any
 
-DATA_SCHEMA = vol.Schema(
-    {
-        vol.Required("username"): str,
-        vol.Required("password"): str,
-    }
-)
+
+_VOLUPTUOUS: ModuleType | None = None
 
 
 class ConfigFlow(config_entries.ConfigFlow):
@@ -28,6 +26,28 @@ class ConfigFlow(config_entries.ConfigFlow):
 
     VERSION = 1
     domain = DOMAIN
+
+    async def _async_get_data_schema(self) -> VolSchema:
+        """Return the data schema, importing voluptuous lazily."""
+
+        global _VOLUPTUOUS
+
+        if _VOLUPTUOUS is None:
+            _VOLUPTUOUS = cast(
+                ModuleType,
+                await self.hass.async_add_executor_job(
+                    importlib.import_module, "voluptuous"
+                ),
+            )
+
+        vol = _VOLUPTUOUS
+
+        return vol.Schema(
+            {
+                vol.Required("username"): str,
+                vol.Required("password"): str,
+            }
+        )
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Handle the initial step where the user enters credentials."""
@@ -45,9 +65,11 @@ class ConfigFlow(config_entries.ConfigFlow):
                 },
             )
 
+        data_schema = await self._async_get_data_schema()
+
         return self.async_show_form(
             step_id="user",
-            data_schema=DATA_SCHEMA,
+            data_schema=data_schema,
             errors=errors,
         )
 


### PR DESCRIPTION
## Summary
- load voluptuous lazily from the executor during the config flow so the module import no longer blocks the event loop
- build the user form schema on demand once voluptuous is available
- cache the lazily imported voluptuous module at the module level so the config flow handler can be constructed normally

## Testing
- python -m compileall custom_components/kumo_cloud

------
https://chatgpt.com/codex/tasks/task_e_68d34d3ffb608333bb8f427e0a40335d